### PR TITLE
Create main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Publish plugin
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Publish
+        uses: sakebook/actions-flutter-pub-publisher@v1.3.1
+        with:
+          credential: ${{ secrets.CREDENTIAL_JSON }}
+          flutter_package: true
+          skip_test: true
+          dry_run: false


### PR DESCRIPTION
Added workflow for automatic publishing to the https://pub.dev/.

**CREDENTIAL_JSON** - is required.

Follow this instruction https://github.com/sakebook/actions-flutter-pub-publisher#credential to get data for **CREDENTIAL_JSON** then add it to the settings in the secrets section of the repository.

![image](https://user-images.githubusercontent.com/30177329/112960557-34d7cf80-914d-11eb-9edc-1da283644872.png)