### PR TITLE
Update sliver_header_delegate.dart

### DIFF
--- a/lib/sliver_header_delegate.dart
+++ b/lib/sliver_header_delegate.dart
@@ -64,7 +64,7 @@ class FlexibleHeaderDelegate extends SliverPersistentHeaderDelegate {
           Container(
             height: visibleMainHeight,
             padding: EdgeInsets.only(top: statusBarHeight),
-            color: backgroundColor ?? Theme.of(context).appBarTheme.color,
+            color: backgroundColor ?? Theme.of(context).appBarTheme.backgroundColor,
             child: Stack(
               fit: StackFit.expand,
               children: [


### PR DESCRIPTION
Flutter 3.10  Error: The getter 'color' isn't defined for the class 'AppBarTheme'.